### PR TITLE
Migrate to Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN mvn install
 
 # Inject the JAR file into a new container to keep the file small
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre-slim
 WORKDIR /app
 COPY --from=build /app/target/hello-java-spring-boot-*.jar /app/app.jar
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>hello-java-spring-boot</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Resolves #6.

Migrates the build from Java 11 to Java 17 (via OpenRewrite `UpgradeBuildToJava17`):
- `pom.xml` `java.version` 11 → 17
- `Dockerfile` base image `openjdk:11-jre-slim` → `eclipse-temurin:17-jre-slim`

Verified locally: `mvn verify` is green under Temurin 17 (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
